### PR TITLE
Add a Baseline Vibration mechanic

### DIFF
--- a/LethalVibrations/Buttplug/Config.cs
+++ b/LethalVibrations/Buttplug/Config.cs
@@ -11,7 +11,8 @@ namespace LethalVibrations.Buttplug
 
         internal static ConfigEntry<float> VibrateAmplifier { get; set; }
         internal static ConfigEntry<bool> Rewarding { get; set; }
-
+        internal static ConfigEntry<float> BaseVibration { get; set }
+        
         #region Damage recieved config entries
         internal static ConfigEntry<bool> VibrateDamageReceivedEnabled { get; set; }
         internal static ConfigEntry<float> VibrateDamageReceivedDuration { get; set; }
@@ -93,6 +94,9 @@ namespace LethalVibrations.Buttplug
 
             #region Rewarding stuff
             Rewarding = ConfigFile.Bind("Vibrations", "Rewarding", true, "Enable rewarding");
+
+            BaseVibration =
+                ConfigFile.Bind("Vibrations", "Base", 0.0f, "Change the base (constant) value of vibration");
             
             VibrateDamageDealtEnabled = ConfigFile.Bind("Vibrations.DamageDealt", "Enabled", true, "Vibrate when you deal damage");
             VibrateDamageDealtDuration = ConfigFile.Bind("Vibrations.DamageDealt", "Duration", 1.0f, "Length of time to vibrate for");

--- a/LethalVibrations/Buttplug/Config.cs
+++ b/LethalVibrations/Buttplug/Config.cs
@@ -10,8 +10,8 @@ namespace LethalVibrations.Buttplug
         internal static ConfigEntry<string> ServerUri { get; set; }
 
         internal static ConfigEntry<float> VibrateAmplifier { get; set; }
-        internal static ConfigEntry<bool> Rewarding { get; set; }
         internal static ConfigEntry<float> BaseVibration { get; set }
+        internal static ConfigEntry<bool> Rewarding { get; set; }
         
         #region Damage recieved config entries
         internal static ConfigEntry<bool> VibrateDamageReceivedEnabled { get; set; }
@@ -91,13 +91,12 @@ namespace LethalVibrations.Buttplug
 
             VibrateAmplifier =
                 ConfigFile.Bind("Vibrations", "Amplifier", 0.0f, "Change the amplification of vibration");
+            BaseVibration =
+                ConfigFile.Bind("Vibrations", "Base", 0.0f, "Change the base (constant) value of vibration");
 
             #region Rewarding stuff
             Rewarding = ConfigFile.Bind("Vibrations", "Rewarding", true, "Enable rewarding");
 
-            BaseVibration =
-                ConfigFile.Bind("Vibrations", "Base", 0.0f, "Change the base (constant) value of vibration");
-            
             VibrateDamageDealtEnabled = ConfigFile.Bind("Vibrations.DamageDealt", "Enabled", true, "Vibrate when you deal damage");
             VibrateDamageDealtDuration = ConfigFile.Bind("Vibrations.DamageDealt", "Duration", 1.0f, "Length of time to vibrate for");
             VibrateDamageDealtStrength = ConfigFile.Bind("Vibrations.DamageDealt", "Strength", 0.5f, "Change the strength of vibration");

--- a/LethalVibrations/Buttplug/DeviceManager.cs
+++ b/LethalVibrations/Buttplug/DeviceManager.cs
@@ -13,7 +13,8 @@ namespace LethalVibrations.Buttplug
     {
         private List<ButtplugClientDevice> ConnectedDevices { get; set; }
         private ButtplugClient ButtplugClient { get; set; }
-
+        private float BaseVibration = Mathf.Clamp((float)Config.BaseVibration.Value, 0f, 1.0f)
+            
         public DeviceManager(string clientName)
         {
             ConnectedDevices = new List<ButtplugClientDevice>();
@@ -51,7 +52,7 @@ namespace LethalVibrations.Buttplug
             {
                 await device.VibrateAsync(Mathf.Clamp((float)intensity, 0f, 1.0f));
                 await Task.Delay((int)(time * 1000f));
-                await device.VibrateAsync(0.0f);
+                await device.VibrateAsync(BaseVibration);
             }
 
             ConnectedDevices.ForEach(Action);


### PR DESCRIPTION
Small change to the config file and VibrateConnectedDevicesWithDuration that allows a "BaseVibration" value to be specified. 

When VibrateConnectedDevicesWithDuration is called, rather than returning the device's vibration to 0, it returns it to the BaseVibration (which is clamped between 0 and 1).